### PR TITLE
Introducing aws_xray_tracing_config in config.yaml in order to set tr…

### DIFF
--- a/aws_lambda/aws_lambda.py
+++ b/aws_lambda/aws_lambda.py
@@ -539,6 +539,9 @@ def create_function(cfg, path_to_zip_file, use_s3=False, s3_file=None):
                 'SecurityGroupIds': cfg.get('security_group_ids', []),
             },
             'Publish': True,
+            'TracingConfig': {
+                'Mode': cfg.get('aws_xray_tracing_config', 'PassThrough')
+            },
         }
     else:
         kwargs = {
@@ -555,6 +558,9 @@ def create_function(cfg, path_to_zip_file, use_s3=False, s3_file=None):
                 'SecurityGroupIds': cfg.get('security_group_ids', []),
             },
             'Publish': True,
+            'TracingConfig': {
+                'Mode': cfg.get('aws_xray_tracing_config', 'PassThrough')
+            },
         }
 
     if 'tags' in cfg:
@@ -635,6 +641,9 @@ def update_function(
         'VpcConfig': {
             'SubnetIds': cfg.get('subnet_ids', []),
             'SecurityGroupIds': cfg.get('security_group_ids', []),
+        },
+        'TracingConfig': {
+            'Mode': cfg.get('aws_xray_tracing_config', 'PassThrough')
         },
     }
 

--- a/aws_lambda/project_templates/config.yaml
+++ b/aws_lambda/project_templates/config.yaml
@@ -16,6 +16,9 @@ runtime: python2.7
 aws_access_key_id:
 aws_secret_access_key:
 
+# set xray tracing config to either PassThrough or Active
+aws_xray_tracing_config: PassThrough
+
 # dist_directory: dist
 # timeout: 15
 # memory_size: 512


### PR DESCRIPTION
…acing active when deploying the function to AWS. By default or if nothing specified the configuration will remain PassThrough which is the default setting and which does not create any extra costs. However setting this to Active will cost (at least eventually).